### PR TITLE
Fix for bug in centerEdgeColor computation

### DIFF
--- a/mycode/findColorTriplets.m
+++ b/mycode/findColorTriplets.m
@@ -126,7 +126,7 @@ while nnz(remainingEdgeMap) && nbCheckedEdges < args.MaxNbEdges
     centerPatchColRange = patchC(curInd)-centerPatchHalfSize(2):patchC(curInd)+centerPatchHalfSize(2);
 
     centerSqColorPatch = img(centerPatchRowRange, centerPatchColRange, :);
-    centerEdgeColor = reshape(centerSqColorPatch, size(centerSqColorPatch,3), size(centerSqColorPatch,1)*size(centerSqColorPatch,2));
+    centerEdgeColor = reshape(permute(centerSqColorPatch, [3 1 2]), [], size(centerSqColorPatch,1)*size(centerSqColorPatch,2));
     nbCenterEdges = size(centerEdgeColor, 2);
     
     % check for monotonicity: if the edge color lies within the bounding


### PR DESCRIPTION
The previous code generates the RGB triplets incorrectly. What is expected is that each column contains an RGB triplet, but the previous will actually fill columnwise and not channelwise.